### PR TITLE
X11 forwarding on Mac + docker 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .ipynb_checkpoints/
 Untitled.ipynb
+eic-shell


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Forward X11 from inside the docker container on macOS
Use cases: Use container root, useful where web-based display isn't enough; other GUIs, such as GEANT4 (not tested, may need OpenGL fiddling)
- Note: not needed with singularity where X11 forwarding works out of the box

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ x ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Documentation has been added / updated --> See below for Notes
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No. None. 

### Does this PR change default behavior?
No, but see notes

### Notes:
- To avoid any default behavior change, users need to use "-X". This is documented in "-h" which should be added to the README. But the changes are light. To work, users need to check a box one time in the settings. However, the worst case scenario is that X11 doesn't work, not a breaking error.
