### PR TITLE
fix: allow `eic-shell --upgrade` on cvmfs

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -277,8 +277,8 @@ if [ ! -z \${UPGRADE} ]; then
     echo "      instantiate a local version."
     echo "      This is only recommended for expert usage."
     echo ""
-    echo "Exiting without upgrade"
-    exit 0
+    echo "This will only upgrade the eic-shell script itself."
+    echo ""
   fi
   FLAGS="-p \${PREFIX} -v \${VERSION}"
   if [ ! -z \${TMPDIR} ]; then


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Ironically, `eic-shell --upgrade` updated `eic-shell` for non-cvmfs users; `eic-shell --upgrade --no-cvmfs` updated `eic-shell` for cvmfs users but took their cvmfs functionality away; and the only way cvmfs users could upgrade `eic-shell` was manually with `curl -L get.epic-eic.org | bash -` in their prefix directory...

This PR ensures that `eic-shell --upgrade` also updates `eic-shell` for cvmfs users, and just notes that this isn't required to update the container.

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.