### PR TITLE
Fix for older xorg crud

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -407,7 +407,7 @@ EOF
 
   if [ `uname -s` = 'Darwin' ]; then
       echo 'if [ ! ${NOX} ]; then' >> eic-shell
-      echo ' nolisten=`defaults find nolisten_tcp | grep nolisten | awk ' "'{print" '$3}'"'" '|cut -b 1 `' >> eic-shell
+      echo ' nolisten=`defaults find nolisten_tcp | grep nolisten | head -n 1 | awk ' "'{print" '$3}'"'" '|cut -b 1 `' >> eic-shell
       echo ' [[ $nolisten -ne 0 ]] && echo "For X support: In XQuartz settings --> Security --> enable \"Allow connections from network clients\" and restart (should be only once)."' >> eic-shell
       ## getting the following single and double quotes, escapes and backticks right was a nightmare
       ## But with a heredoc it was worse


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Some Macs have remnants from an older XQuartz installations. Specifically the key ``nolisten_tcp` is found in both org.xquartz.X11 and org.macosforge.xquartz.X11, upsetting the grep command to determine if "Allow connections from network clients" is needed. This fixes that in a crufty way, i.e. assuming that the first find i the correct one.

### What kind of change does this PR introduce?
- [X] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No

### Does this PR change default behavior?
No