### PR TITLE
fix: add `/media` to singularity bindpath

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -185,7 +185,7 @@ function install_singularity() {
   BINDPATH=${SINGULARITY_BINDPATH}
   echo "   --> system bindpath: $BINDPATH"
   PREFIX_ROOT="/$(realpath $PREFIX | cut -d "/" -f2)"
-  for dir in /w /work /scratch /volatile /cache /gpfs /gpfs01 /gpfs02 $PREFIX_ROOT; do
+  for dir in /w /work /media /scratch /volatile /cache /gpfs /gpfs01 /gpfs02 $PREFIX_ROOT; do
     ## only add directories once
     if [[ ${BINDPATH} =~ $(basename $dir) ]]; then
       continue


### PR DESCRIPTION
### Briefly, what does this PR introduce?
In `eic-shell`, users want to access external media which are mounted under `/media`. This PR adds the `/media` path to the paths that are considered for adding automatically to the default bindpath.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: users cannot access external media)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.